### PR TITLE
Add missing build dependency on dh addon

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+context-modules (20200331-2) UNRELEASED; urgency=medium
+
+  * Add missing build dependency on dh addon.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 06 May 2020 08:57:00 +0000
+
 context-modules (20200331-1) unstable; urgency=medium
 
   [ Debian Janitor ]

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: tex
 Priority: optional
 Maintainer: Debian TeX maintainers <debian-tex-maint@lists.debian.org>
 Uploaders: Norbert Preining <norbert@preining.info>
-Build-Depends: debhelper-compat (= 12)
+Build-Depends: debhelper-compat (= 12), tex-common
 Build-Depends-Indep: tex-common (>= 2.10)
 Standards-Version: 4.2.1
 Vcs-Git: https://github.com/debian-tex/context-modules.git


### PR DESCRIPTION
Add missing build dependency on dh addon. ([missing-build-dependency-for-dh_command](https://lintian.debian.org/tags/missing-build-dependency-for-dh_command.html))

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/context-modules/42df2144-a51b-4073-8b3e-a72a61be8506.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/42df2144-a51b-4073-8b3e-a72a61be8506/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/42df2144-a51b-4073-8b3e-a72a61be8506/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/42df2144-a51b-4073-8b3e-a72a61be8506/diffoscope)).
