### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,6 @@ Vcs-Git: https://github.com/debian-tex/context-modules.git
 Vcs-Browser: https://github.com/debian-tex/context-modules
 
 Package: context-modules
-Section: tex
 Architecture: all
 Depends: context, ${misc:Depends}
 Description: additional ConTeXt modules

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: tex
 Priority: optional
 Maintainer: Debian TeX maintainers <debian-tex-maint@lists.debian.org>
 Uploaders: Norbert Preining <norbert@preining.info>
-Build-Depends: debhelper-compat (= 12), tex-common
+Build-Depends: debhelper-compat (= 13), tex-common
 Build-Depends-Indep: tex-common
 Standards-Version: 4.2.1
 Vcs-Git: https://github.com/debian-tex/context-modules.git


### PR DESCRIPTION
Fix some issues reported by lintian

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Remove Section on context-modules that duplicates source. ([installable-field-mirrors-source](https://lintian.debian.org/tags/installable-field-mirrors-source))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/context-modules/ba9b714c-c147-49ba-b380-a0c5b4125d55.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/ba9b714c-c147-49ba-b380-a0c5b4125d55/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/ba9b714c-c147-49ba-b380-a0c5b4125d55/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/ba9b714c-c147-49ba-b380-a0c5b4125d55/diffoscope)).
