### PR TITLE
replace wiki link with the modules homepage

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Standards-Version: 4.2.1
 Rules-Requires-Root: no
 Vcs-Git: https://github.com/debian-tex/context-modules.git
 Vcs-Browser: https://github.com/debian-tex/context-modules
-Homepage: https://wiki.contextgarden.net/Modules
+Homepage: https://modules.contextgarden.net
 
 Package: context-modules
 Architecture: all


### PR DESCRIPTION
The wiki link is fine, but the real homepage is: https://modules.contextgarden.net/ and the full module list is https://modules.contextgarden.net/cgi-bin/module.cgi/action=listall