### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/context-modules.lintian-overrides
+++ b/debian/context-modules.lintian-overrides
@@ -1,6 +1,6 @@
 context-modules: script-not-executable
-context-modules: extra-license-file usr/share/texmf/doc/context/third/cyrillicnumbers/COPYING
-context-modules: extra-license-file usr/share/texmf/doc/context/third/transliterator/COPYING
+context-modules: extra-license-file [usr/share/texmf/doc/context/third/cyrillicnumbers/COPYING]
+context-modules: extra-license-file [usr/share/texmf/doc/context/third/transliterator/COPYING]
 # We are in TeX world:
 context-modules: package-contains-documentation-outside-usr-share-doc
 context-modules: repeated-path-segment

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Debian TeX Task Force <debian-tex-maint@lists.debian.org>
 Uploaders: Norbert Preining <norbert@preining.info>,
 	   Hilmar Preusse <hille42@web.de>
 Build-Depends: debhelper-compat (= 13), tex-common
-Standards-Version: 4.6.0
+Standards-Version: 4.6.2
 Rules-Requires-Root: no
 Vcs-Git: https://github.com/debian-tex/context-modules.git
 Vcs-Browser: https://github.com/debian-tex/context-modules


### PR DESCRIPTION
Fix some issues reported by lintian

* Update lintian override info format in d/context-modules.lintian-overrides on line 2-3. ([mismatched-override](https://lintian.debian.org/tags/mismatched-override))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

These changes have no impact on the [binary debdiff](https://janitor.debian.net/api/run/24d5bb81-919b-4c94-aaf6-402262f520eb/debdiff?filter_boring=1).

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/24d5bb81-919b-4c94-aaf6-402262f520eb/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/24d5bb81-919b-4c94-aaf6-402262f520eb/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/context-modules/24d5bb81-919b-4c94-aaf6-402262f520eb.